### PR TITLE
Update exampe-symfony.rst

### DIFF
--- a/doc/transformable/exampe-symfony.rst
+++ b/doc/transformable/exampe-symfony.rst
@@ -25,11 +25,7 @@ Configure services:
 
         mediamonks.doctrine.transformable.transformer.laminas_crypt_hmac:
             class: MediaMonks\Doctrine\Transformable\Transformer\LaminasCryptHmacTransformer
-            arguments: [%hmac_key%]
-
-        mediamonks.doctrine.transformable.transformer.halite_encrypt:
-            class: MediaMonks\Doctrine\Transformable\Transformer\LibsodiumSymmetricTransformer
-            arguments: [%encryption_key%]
+            arguments: ["%hmac_key%"]
 
         mediamonks.doctrine.transformable.transformer_pool:
             class: MediaMonks\Doctrine\Transformable\Transformer\TransformerPool
@@ -38,7 +34,6 @@ Configure services:
                 - [set, ['laminas_encrypt', "@mediamonks.doctrine.transformable.transformer.laminas_crypt_symmetric"]]
                 - [set, ['laminas_hash', "@mediamonks.doctrine.transformable.transformer.laminas_crypt_hash"]]
                 - [set, ['laminas_hmac', "@mediamonks.doctrine.transformable.transformer.laminas_crypt_hmac"]]
-                - [set, ['halite_encrypt', "@mediamonks.doctrine.transformable.transformer.halite_encrypt"]]
 
         doctrine.transformable.subscriber:
             class: MediaMonks\Doctrine\Transformable\TransformableSubscriber


### PR DESCRIPTION
Quoted values are required for parameters to prevent : The file "C:\laragon\www\dashboard\app/config/services.yaml" does not contain valid YAML: The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 37 (near "arguments: [%encryption_key%]") in C:\laragon\www\dashboard\app/config/services.yaml (which is being imported from "C:\laragon\www\dashboard\app\src\Kernel.php").

The class MediaMonks\Doctrine\Transformable\Transformer\LibsodiumSymmetricTransformer seems to not exist anymore.